### PR TITLE
Fix rage plugin namespace error

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -6,9 +6,9 @@ using Rage;
 
 namespace ConvoyBreakerCallout
 {
-    public class Plugin : Rage.Plugin
+    public class Plugin
     {
-        public override void Initialize()
+        public static void Initialize()
         {
             // Subscribe to on-duty state changes
             Functions.OnOnDutyStateChanged += OnOnDutyStateChangedHandler;
@@ -20,7 +20,7 @@ namespace ConvoyBreakerCallout
             Game.LogTrivial("===========================================");
         }
 
-        public override void Finally()
+        public static void Finally()
         {
             Game.LogTrivial("ConvoyBreakerCallout: Plugin cleanup completed.");
         }


### PR DESCRIPTION
Refactor Plugin.cs to use the correct LSPDFR plugin structure, resolving a `Rage.Plugin` namespace error.

The original code attempted to inherit from `Rage.Plugin`, which does not exist in the LSPDFR framework, leading to a build error. LSPDFR plugins typically do not inherit from a base plugin class, and their entry point methods (`Initialize`, `Finally`) are static.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0c38b05-0fd7-44cd-89d6-c5fb63e995c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a0c38b05-0fd7-44cd-89d6-c5fb63e995c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

