### PR TITLE
Fix vehicle and world method errors

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -193,7 +193,7 @@ namespace ConvoyBreakerCallout
             // Lead SUV - 2 scouts with rifles
             var leadDriver = leadSUV.CreateRandomDriver();
             var leadGunner = new Ped("G_M_Y_MexGang_01", leadSUV.Position, 0f);
-            leadGunner.WarpIntoVehicle(leadSUV, 0); // 0 = Passenger seat
+            leadGunner.WarpIntoVehicle(leadSUV, 1); // 1 = Passenger seat (0 is driver)
             
             leadDriver.Inventory.GiveNewWeapon("WEAPON_ASSAULTRIFLE", 200, true);
             leadGunner.Inventory.GiveNewWeapon("WEAPON_CARBINERIFLE", 200, true);
@@ -212,9 +212,9 @@ namespace ConvoyBreakerCallout
             // Rear SUV - heavily armed escort
             var rearDriver = rearSUV.CreateRandomDriver();
             var rearGunner = new Ped("G_M_Y_MexGang_01", rearSUV.Position, 0f);
-            rearGunner.WarpIntoVehicle(rearSUV, 0); // 0 = Passenger seat
+            rearGunner.WarpIntoVehicle(rearSUV, 1); // 1 = Passenger seat (0 is driver)
             var rearEnforcer = new Ped("G_M_Y_MexGang_01", rearSUV.Position, 0f);
-            rearEnforcer.WarpIntoVehicle(rearSUV, 1); // 1 = Left rear seat
+            rearEnforcer.WarpIntoVehicle(rearSUV, 2); // 2 = Left rear seat (1 is passenger)
             
             rearDriver.Inventory.GiveNewWeapon("WEAPON_ASSAULTRIFLE", 200, true);
             rearGunner.Inventory.GiveNewWeapon("WEAPON_MG", 300, true);  // Light machine gun
@@ -316,8 +316,8 @@ namespace ConvoyBreakerCallout
                     ghostSniper = operative;
                     
                     // Position sniper on elevated position
-                    var nearbyObjects = World.GetAllObjects();
-                    var nearbyProps = nearbyObjects.Where(o => o.Exists() && Vector3.Distance(o.Position, operative.Position) < 50f).ToArray();
+                    var allEntities = World.GetAllEntities();
+                    var nearbyProps = allEntities.OfType<Rage.Object>().Where(o => o.Exists() && Vector3.Distance(o.Position, operative.Position) < 50f).ToArray();
                     if (nearbyProps.Length > 0)
                     {
                         operative.Position = nearbyProps[0].Position + Vector3.WorldUp * 10f;
@@ -591,7 +591,7 @@ namespace ConvoyBreakerCallout
             PlayRadioChatter("Ghost Lead", "Lights out! Switch to night vision, we own the dark now.");
             
             // Create blackout effect
-            World.Weather = Weather.ExtraSunny; // Ensure it's not already dark
+            Game.Weather = "EXTRASUNNY"; // Ensure it's not already dark
             NativeFunction.Natives.SET_ARTIFICIAL_LIGHTS_STATE(false);
             
             GameFiber.StartNew(() =>


### PR DESCRIPTION
Fix compilation errors by updating RagePluginHook API calls for weather, object retrieval, and vehicle seat indexing.

The original error messages referenced methods not present in the provided code. This PR addresses the actual API discrepancies found, specifically replacing `World.GetAllObjects()` with `World.GetAllEntities().OfType<Rage.Object>()`, updating `World.Weather = Weather.ExtraSunny` to `Game.Weather = "EXTRASUNNY"`, and correcting `WarpIntoVehicle` seat indices (0 is driver).

---
<a href="https://cursor.com/background-agent?bcId=bc-61ee8238-569a-40f3-9984-ee537432ea26">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-61ee8238-569a-40f3-9984-ee537432ea26">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

