### PR TITLE
Fix game weather definition error

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -591,7 +591,7 @@ namespace ConvoyBreakerCallout
             PlayRadioChatter("Ghost Lead", "Lights out! Switch to night vision, we own the dark now.");
             
             // Create blackout effect
-            Game.Weather = "EXTRASUNNY"; // Ensure it's not already dark
+            NativeFunction.Natives.SET_WEATHER_TYPE_NOW("EXTRASUNNY"); // Ensure it's not already dark
             NativeFunction.Natives.SET_ARTIFICIAL_LIGHTS_STATE(false);
             
             GameFiber.StartNew(() =>


### PR DESCRIPTION
Replace `Game.Weather` with `NativeFunction.Natives.SET_WEATHER_TYPE_NOW` to fix a build error where `Game.Weather` does not exist in the API.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba49a5ea-5ce7-450d-bc8c-098f4f352467">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba49a5ea-5ce7-450d-bc8c-098f4f352467">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

