### PR TITLE
Fix compilation errors in DiagnosticHelper and Main

### DIFF
--- a/DiagnosticHelper.cs
+++ b/DiagnosticHelper.cs
@@ -22,7 +22,7 @@ namespace ConvoyBreakerCallout
                     writer.WriteLine($"Game Version: {Game.ProductVersion}");
                     writer.WriteLine($"LSPDFR Version: {Functions.GetVersion()}");
                     writer.WriteLine($"Plugin Assembly Location: {typeof(Plugin).Assembly.Location}");
-                    writer.WriteLine($"Is LSPDFR Running: {Functions.IsLSPDFRRunning()}");
+                    writer.WriteLine($"Is Player On Duty: {Functions.IsPlayerOnDuty()}");
                     writer.WriteLine($"Player Character Exists: {Game.LocalPlayer?.Character?.Exists()}");
                     writer.WriteLine($"Current Position: {Game.LocalPlayer?.Character?.Position}");
                     writer.WriteLine("=== END DIAGNOSTIC INFO ===");
@@ -44,7 +44,7 @@ namespace ConvoyBreakerCallout
                 Game.LogTrivial("=== CONVOY BREAKER FUNCTIONALITY TEST ===");
                 
                 // Test 1: Basic LSPDFR functions
-                Game.LogTrivial($"Test 1 - LSPDFR Running: {Functions.IsLSPDFRRunning()}");
+                Game.LogTrivial($"Test 1 - Player On Duty: {Functions.IsPlayerOnDuty()}");
                 
                 // Test 2: Player character
                 var playerExists = Game.LocalPlayer?.Character?.Exists() ?? false;

--- a/Main.cs
+++ b/Main.cs
@@ -318,9 +318,9 @@ namespace ConvoyBreakerCallout
             Game.LogTrivial($"ConvoyBreakerCallout: Lead SUV driving to destination: {convoyDestination}");
             
             // Other vehicles follow the lead vehicle in formation
-            cargoTruck1.Driver.Tasks.FollowToOffsetFromEntity(leadSUV, Vector3.RelativeBack * 15f, 20f);
-            cargoTruck2.Driver.Tasks.FollowToOffsetFromEntity(cargoTruck1, Vector3.RelativeBack * 15f, 20f);
-            rearSUV.Driver.Tasks.FollowToOffsetFromEntity(cargoTruck2, Vector3.RelativeBack * 15f, 20f);
+            cargoTruck1.Driver.Tasks.FollowToOffsetFromEntity(leadSUV, Vector3.RelativeBack * 15f, 20f, VehicleDrivingFlags.Normal);
+            cargoTruck2.Driver.Tasks.FollowToOffsetFromEntity(cargoTruck1, Vector3.RelativeBack * 15f, 20f, VehicleDrivingFlags.Normal);
+            rearSUV.Driver.Tasks.FollowToOffsetFromEntity(cargoTruck2, Vector3.RelativeBack * 15f, 20f, VehicleDrivingFlags.Normal);
             
             Game.LogTrivial("ConvoyBreakerCallout: Convoy AI tasks assigned. Convoy should now be moving.");
         }


### PR DESCRIPTION
Update LSPDFR API calls and `FollowToOffsetFromEntity` method signatures to resolve compilation errors.

`Functions.IsLSPDFRRunning()` was causing a CS0117 error as it does not exist in the LSPDFR API. `Functions.IsPlayerOnDuty()` was used as a valid and functionally similar replacement for diagnostic purposes. `Tasks.FollowToOffsetFromEntity` was called with 3 arguments, leading to a CS1501 error. The correct overload requires 4 arguments, with `VehicleDrivingFlags.Normal` being the missing parameter.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0cd6b54-e2b0-445b-a6e7-17dd90569e76">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0cd6b54-e2b0-445b-a6e7-17dd90569e76">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

