### PR TITLE
Fix lpsdfr plugin loading and callout

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -121,7 +121,7 @@ namespace ConvoyBreakerCallout
                 Functions.PlayScannerAudioUsingPosition("ATTENTION_ALL_UNITS WE_HAVE CRIME_GANG_RELATED IN_OR_ON_POSITION", ambushPoint);
                 
                 Game.LogTrivial("ConvoyBreakerCallout: OnBeforeCalloutDisplayed - Setup completed successfully");
-                return base.OnBeforeCalloutDisplayed();
+                return true;
             }
             catch (Exception ex)
             {

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -8,7 +8,7 @@ namespace ConvoyBreakerCallout
 {
     public class Plugin
     {
-        public static void Initialize()
+        public static void Main()
         {
             try
             {
@@ -22,6 +22,16 @@ namespace ConvoyBreakerCallout
                 Game.LogTrivial("  Operation: Convoy Breaker - Loaded");
                 Game.LogTrivial("  Tactical cartel interdiction callout");
                 Game.LogTrivial("===========================================");
+                
+                // If the player is already on duty, register immediately
+                if (Functions.IsPlayerOnDuty())
+                {
+                    Game.LogTrivial("ConvoyBreakerCallout: Player already on duty at load; registering callout now...");
+                    Functions.RegisterCallout(typeof(ConvoyBreakerCallout));
+                    Game.DisplayNotification("web_lossantospolicedept", "web_lossantospolicedept", 
+                        "~w~CONVOY BREAKER", "~b~Tactical Callout Loaded", 
+                        "~w~Black operations callout now available. Stay frosty, operator.");
+                }
                 
                 // Run diagnostic tests
                 DiagnosticHelper.LogDiagnosticInfo();
@@ -40,6 +50,7 @@ namespace ConvoyBreakerCallout
         {
             try
             {
+                Functions.OnOnDutyStateChanged -= OnOnDutyStateChangedHandler;
                 Game.LogTrivial("ConvoyBreakerCallout: Plugin cleanup completed.");
             }
             catch (Exception ex)


### PR DESCRIPTION
Resolves LSPDFR plugin and callout loading failures by updating the entry point, registration logic, and event cleanup.

The plugin's entry point was renamed from `Initialize()` to `Main()` to comply with RAGEPluginHook's loading requirements. Immediate callout registration was added for scenarios where the player is already on duty when the plugin loads. Additionally, the `OnOnDutyStateChanged` event handler is now unsubscribed in `Finally()` to prevent lingering subscriptions, and `OnBeforeCalloutDisplayed` explicitly returns `true` to ensure callouts display after successful setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-626fb562-d7ac-4ed5-93d2-bec10d5eba8e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-626fb562-d7ac-4ed5-93d2-bec10d5eba8e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

