### PR TITLE
Fix missing tasks namespace reference

### DIFF
--- a/TasksCompatExtensions.cs
+++ b/TasksCompatExtensions.cs
@@ -11,7 +11,7 @@ namespace ConvoyBreakerCallout
 		/// Compatibility shim: allow using 3-argument FollowToOffsetFromEntity across different RPH versions.
 		/// Resolves to the available overload and supplies sensible default values for missing parameters.
 		/// </summary>
-		public static void FollowToOffsetFromEntity(this Tasks tasks, Entity targetEntity, Vector3 offset, float movementSpeed)
+		public static void FollowToOffsetFromEntity(this Rage.Tasks tasks, Entity targetEntity, Vector3 offset, float movementSpeed)
 		{
 			if (tasks == null) throw new ArgumentNullException(nameof(tasks));
 			if (targetEntity == null) throw new ArgumentNullException(nameof(targetEntity));
@@ -19,7 +19,7 @@ namespace ConvoyBreakerCallout
 			try
 			{
 				// Find instance methods named FollowToOffsetFromEntity
-				var candidateMethods = typeof(Tasks)
+				var candidateMethods = typeof(Rage.Tasks)
 					.GetMethods(BindingFlags.Public | BindingFlags.Instance)
 					.Where(m => m.Name == nameof(FollowToOffsetFromEntity))
 					.ToArray();


### PR DESCRIPTION
Qualify `Tasks` with `Rage.Tasks` in `TasksCompatExtensions.cs` to fix a CS0246 build error by correctly referencing the Rage framework type.

---
<a href="https://cursor.com/background-agent?bcId=bc-c2c8c69d-a790-4758-9085-0b189271d80c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c2c8c69d-a790-4758-9085-0b189271d80c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

